### PR TITLE
Update elasticache_cluster limit to 40

### DIFF
--- a/resources.tf
+++ b/resources.tf
@@ -16,7 +16,7 @@ locals {
     "ecs_cluster"                         = "255" # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateCluster.html#ECS-CreateCluster-request-clusterName
     "ecs_service"                         = "255" # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html#ECS-CreateService-request-serviceName
     "ecs_task_definition"                 = "255" # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html#ECS-RegisterTaskDefinition-request-family
-    "elasticache_cluster"                 = "20"  # https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheCluster.html
+    "elasticache_cluster"                 = "40"  # https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheCluster.html
     "elasticache_parameter_group"         = "255" # https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/ParameterGroups.Creating.html
     "elasticsearch_domain"                = "28"  # https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomains
     "iam_instance_profile"                = "128" # https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #36

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-resource-naming/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note


ENHANCEMENTS:
* Update elasticache_cluster naming limit to 40 characters (see https://aws.amazon.com/about-aws/whats-new/2019/08/elasticache_supports_50_chars_cluster_name/)

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->